### PR TITLE
adios2store: handle redundant coordinates

### DIFF
--- a/src/xarray_adios2/adios2array.py
+++ b/src/xarray_adios2/adios2array.py
@@ -21,14 +21,18 @@ class Adios2Array(BackendArray):
         self,
         variable_name: str,
         datastore: Adios2Store,
+        step: int | None = None,
     ) -> None:
         self.variable_name = variable_name
         self.datastore = datastore
+        self.step = step
         array = self.get_array()
         self.shape = array.shape
         self.dtype = array.dtype
 
     def get_array(self, needs_lock: bool = True) -> adios2py.ArrayProxy:
+        if self.step is not None:
+            return self.datastore.acquire(needs_lock).steps[0][self.variable_name]  # type: ignore[attr-defined, no-any-return]
         return self.datastore.acquire(needs_lock)[self.variable_name]
 
     def __getitem__(self, key: indexing.ExplicitIndexer) -> NDArray[Any]:

--- a/tests/test_open_dataset.py
+++ b/tests/test_open_dataset.py
@@ -72,12 +72,11 @@ def test_open_by_step(filename, sample_dataset, request):
         assert ds.keys() == sample_dataset.keys()
         assert ds.sizes == sample_dataset.sizes
         assert ds.coords.keys() == sample_dataset.coords.keys()
+        for name, coord in ds.coords.items():
+            assert coord.dims == (name,)
         assert ds.broadcast_equals(sample_dataset)
         for name in sample_dataset.variables:
-            if name == "x":
-                assert np.array_equal(ds[name].isel(time=0), sample_dataset[name])
-            else:
-                assert np.array_equal(ds[name], sample_dataset[name])
+            assert np.array_equal(ds[name], sample_dataset[name])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It's a bit of an open question as to whether this should be done automatically, or should be triggered by a new attribute. The latter really would be better, if more of a hassle to implement and use. So it should be done, and one should expect behavior to change over this PR, which automatically removes redundant dims for coordinates matching the dimension name.